### PR TITLE
Fix bug which can possibly prune a volume

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,7 +168,11 @@ func (d *glusterfsDriver) Remove(r *volume.RemoveRequest) error {
 	empty, err := IsDirEmpty(v.Mountpoint)
 
 	if !empty || err != nil {
-		return logError("Directory for volume %s where the volume is mounted is not empty. This would result in complete removal of all data. Please stop all containers that mount the same volume and subdirectory and try again.", r.Name)
+		return logError(
+			"Directory for volume %s where the volume is mounted is not empty. "+
+				"This would result in complete removal of all data. Please stop all "+
+				"containers that mount the same volume and subdirectory and try again.",
+			r.Name)
 	}
 
 	if err := os.RemoveAll(v.Mountpoint); err != nil {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -21,6 +22,7 @@ const socketAddress = "/run/docker/plugins/glusterfs.sock"
 
 type glusterfsVolume struct {
 	connections      int
+	Name             string
 	Subdir           string
 	SubdirMountpoint string
 	Servers          []string
@@ -85,6 +87,7 @@ func (d *glusterfsDriver) Create(r *volume.CreateRequest) error {
 	defer d.Unlock()
 	v := &glusterfsVolume{
 		Subdir:  r.Name,
+		Name:    r.Name,
 		Volname: d.defaultVolname,
 		Servers: strings.Split(d.defaultServers, ","),
 	}
@@ -120,13 +123,31 @@ func (d *glusterfsDriver) Create(r *volume.CreateRequest) error {
 		return logError("'servers' option required")
 	}
 
-	v.Mountpoint = filepath.Join(d.root, fmt.Sprintf("%x/%x", md5.Sum([]byte(v.Volname)), md5.Sum([]byte(v.Subdir))))
+	v.Mountpoint = filepath.Join(d.root, fmt.Sprintf("%x/%x/%x", sha256.Sum256([]byte(v.Name)), sha256.Sum256([]byte(v.Volname)), sha256.Sum256([]byte(v.Subdir))))
 
 	d.volumes[r.Name] = v
 
 	d.saveState()
 
 	return nil
+}
+
+// https://socketloop.com/tutorials/golang-determine-if-directory-is-empty-with-os-file-readdir-function
+func IsDirEmpty(name string) (bool, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	// read in ONLY one file
+	_, err = f.Readdir(1)
+
+	// and if the file is EOF... well, the dir is empty.
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
 }
 
 func (d *glusterfsDriver) Remove(r *volume.RemoveRequest) error {
@@ -142,6 +163,12 @@ func (d *glusterfsDriver) Remove(r *volume.RemoveRequest) error {
 
 	if v.connections != 0 {
 		return logError("volume %s is currently used by a container", r.Name)
+	}
+
+	empty, err := IsDirEmpty(v.Mountpoint)
+
+	if !empty || err != nil {
+		return logError("Directory for volume %s where the volume is mounted is not empty. This would result in complete removal of all data. Please stop all containers that mount the same volume and subdirectory and try again.", r.Name)
 	}
 
 	if err := os.RemoveAll(v.Mountpoint); err != nil {

--- a/tests/script.sh
+++ b/tests/script.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Test for multiple volumes with same settings.
+# If we create multiple volumes with same settings but different names, 
+# then there should not be a problem with mounting and unmounting
+#
+# This situation resulted in completed volume removal in older versions.
+
+docker volume rm stackb_test-volume
+docker volume rm stacka_test-volume
+
+cd stacka
+docker-compose up -d
+# docker-compose exec alpine2 pwd
+docker-compose exec alpine2 rm -rf /data/*
+
+docker-compose exec alpine2 sh -c 'echo "test" > test_data'
+# docker-compose exec alpine2 cat test_data
+# docker-compose exec alpine2 ls -l
+
+cd ../stackb 
+
+docker-compose up -d # This should crash if not fixed
+docker-compose down 
+docker volume rm stackb_test-volume # This should cause complete volume prune
+
+cd ../stacka
+docker-compose exec alpine2 sh -c 'if [ -f "test_data" ]; then echo "TEST SUCCESSFULL"; else echo "TEST FAIL"; fi;'
+docker-compose down -v
+
+cd ../stackb 
+docker-compose down  -v

--- a/tests/stacka/docker-compose.yml
+++ b/tests/stacka/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services: 
+  alpine2:
+    image: nginx:latest
+    working_dir: /data
+    volumes:
+      - test-volume:/data
+
+volumes:
+  test-volume:
+    driver: urbitech/glusterfs:8
+    driver_opts:
+      volname: gv0
+      subdir: foo

--- a/tests/stackb/docker-compose.yml
+++ b/tests/stackb/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services: 
+  alpine2:
+    image: nginx:latest
+    working_dir: /data
+    volumes:
+      - test-volume:/data
+
+volumes:
+  test-volume: #Notice the difference in docker volume name from Stack A
+    driver: urbitech/glusterfs:8
+    driver_opts:
+      volname: gv0
+      subdir: foo


### PR DESCRIPTION
## What does this PR fix?

This PR fixes an ongoing issue described in https://github.com/mikebarkmin/docker-volume-glusterfs/issues/8 where a user is unable to mount multiple volume with same settings.

## Triage

The problem here is that the plugin keeps all volumes inside a dictionary of structs which are keyed by the volume's name and it creates mountpoint only based on `Volname ` and `Subdir`. 

### Example
Let's create two volumes and insert them into the volumes dictionary:
```json
# test-volume-1
{
  "Subdir":  "foo",
  "Volname": "gv0",
  "Mountpoint": "/mnt/volumes/md5(gv0)/md5(foo)"
}

# test-volume-2
{
  "Subdir":  "foo",
  "Volname": "gv0",
  "Mountpoint": "/mnt/volumes/md5(gv0)/md5(foo)"
}
```
When the docker engine tries to mount the first volume, it succedes. But when mounting the second one it fails with an "expected" error `Path /mnt/..... is already mounted according to fstab`

But when we want to remove the `test-volume-2` which now doesn't have any connections, it goes through and calls `os.RemoveAll(v.Mountpoint)`. This in turn prunes the whole volume.

## Solution
I have added the docker volume name to the `Mountpoint` and implemented a empty directory check before calling `RemoveAll` just incase (we don't want any data to be unintentionally removed)

I have also switched to sha256, because md5 is not a standard anymore.

Lastly I have added a `tests` directory which contains a simple test for this. You need to use the the gluster cluster IP and plugin name in the 2 docker-compose files. After all of this you can run the `script.sh` which should output "TEST SUCCESSFUL"
